### PR TITLE
fixed crash and add globals options.

### DIFF
--- a/pip_utils/cli.py
+++ b/pip_utils/cli.py
@@ -125,9 +125,15 @@ def _parser():
         help='update packages that can be updated'
     )
     parser_outdated.add_argument(
+        '--globals',
+        action='store_true',
+        help='output packages installed in globals.'
+    )
+    parser_outdated.add_argument(
         '-h', '--help',
         action='help',
         help=argparse.SUPPRESS)
+
     parser_outdated.set_defaults(
         func=command_outdated)
 

--- a/pip_utils/outdated.py
+++ b/pip_utils/outdated.py
@@ -51,7 +51,7 @@ class ListCommand(object):
         'version': None,
         'log': None,
         'index_url': 'https://pypi.python.org/simple',
-        'cache_dir': os.path.join(os.environ['HOME'], '.cache/pip'),
+        'cache_dir': None,
         'outdated': True,
         'retries': 5,
         'allow_all_external': False,
@@ -63,6 +63,9 @@ class ListCommand(object):
         'user': ENABLE_USER_SITE,
         'verbose': 0
     }
+
+    if 'HOME' in os.environ:
+        options['cache_dir'] = os.path.join(os.environ['HOME'], '.cache/pip')
 
     @staticmethod
     def _build_package_finder(options, index_urls, session):

--- a/pip_utils/outdated.py
+++ b/pip_utils/outdated.py
@@ -224,6 +224,9 @@ class ListCommand(object):
     @classmethod
     def run_outdated(cls, options):
         """Print outdated user packages."""
+        if options.globals:
+            cls.options['user'] = False
+
         latest_versions = sorted(
             cls.find_packages_latest_versions(cls.options),
             key=lambda p: p[0].project_name.lower())


### PR DESCRIPTION
for `add globals options.`, now I can use `pip3-utils outdated --globals` to show my packages.

#2 